### PR TITLE
Add checkboxgroups for tables columns

### DIFF
--- a/nplinker/main.py
+++ b/nplinker/main.py
@@ -1468,12 +1468,16 @@ class NPLinkerBokeh(object):
         # header text
         self.header_text = Div(
             text=
-            '<strong>NPLinker web app</strong> (loaded BGCs={}, GCFs={}, Spectra={}, MolFams={})'
-            .format(len(self.nh.nplinker.bgcs), len(self.nh.nplinker.gcfs),
-                    len(self.nh.nplinker.spectra),
-                    len(self.nh.nplinker.molfams)),
+            '<p><strong>NPLinker web app</strong></p><p>Loaded {} MolFams, {} Spectra, {} BGCs, and {} GCFs.</p>'
+            .format(
+                len(self.nh.nplinker.molfams),
+                len(self.nh.nplinker.spectra),
+                len(self.nh.nplinker.bgcs),
+                len(self.nh.nplinker.gcfs)),
             name='header_text',
-            sizing_mode='scale_width')
+            #sizing_mode='stretch_both',
+            #aspect_ratio='auto'
+            width_policy='max')
         widgets.append(self.header_text)
 
         self.search_input = TextInput(value='',

--- a/nplinker/nplinker_webapp.toml
+++ b/nplinker/nplinker_webapp.toml
@@ -2,8 +2,7 @@ loglevel = "DEBUG"
 logfile = ""
 repro_file = ""
 [dataset]
-#root = "/mnt/archive/nplinker_data/current/carnegie_mibig_27112019"
-root = "/mnt/archive/nplinker_data/current/crusemann_26112019"
+root = "platform:MSV000079284"
 bigscape_cutoff = 30
 [dataset.overrides]
 [scoring]

--- a/nplinker/server_lifecycle.py
+++ b/nplinker/server_lifecycle.py
@@ -64,6 +64,7 @@ def on_server_loaded(server_context):
     print('==================================')
     print('NPLinker server loading completed!')
     print('==================================')
+    print('NPLinker webapp is served on http://localhost:5006/nplinker')
 
 
 def on_session_created(session_context):

--- a/nplinker/tables_init.py
+++ b/nplinker/tables_init.py
@@ -254,33 +254,33 @@ class TableSessionData(object):
         # place limits on how far you can resize the columns for some reason...
 
         self.molfam_cols = [
-            TableColumn(field='molfam_pk', title='ID', width=15),
+            #TableColumn(field='molfam_pk', title='ID', width=15),
             TableColumn(field='family_id', title='MolFam ID', width=15),
             TableColumn(field='nspectra', title='#spectra', width=15)
         ]
 
         self.spec_cols = [
-            TableColumn(field='spec_pk', title='ID', width=15),
+            #TableColumn(field='spec_pk', title='ID', width=15),
             TableColumn(field='spectrum_id', title='Spectrum ID', width=15),
             TableColumn(field='family', title='Family ID', width=15),
-            TableColumn(field='metcalf_score', title='Metcalf', width=15)
+            TableColumn(field='metcalf_score', title='Metcalf score', width=15)
         ]
 
         self.bgc_cols = [
-            TableColumn(field='bgc_pk', title='ID', width=15),
+            #TableColumn(field='bgc_pk', title='ID', width=15),
             TableColumn(field='name', title='BGC name', width=15),
             TableColumn(field='product_type', title='Product pred.', width=15),
             TableColumn(field='is_hybrid', title='Hybrid?', width=15)
         ]
 
         self.gcf_cols = [
-            TableColumn(field='gcf_pk', title='ID', width=15),
+            #TableColumn(field='gcf_pk', title='ID', width=15),
             TableColumn(field='gcf_id', title='GCF ID', width=15),
             TableColumn(field='bigscape_class',
                         title='BiG-SCAPE',
                         width=15),
             TableColumn(field='nbgcs', title='#bgcs', width=15),
-            TableColumn(field='metcalf_score', title='Metcalf',
+            TableColumn(field='metcalf_score', title='Metcalf score',
                         width=15),
             TableColumn(field='is_pure', title='Pure?', width=15)
         ]
@@ -302,12 +302,12 @@ class TableSessionData(object):
 
         self.bgc_checkbox = CheckboxButtonGroup(
             labels=[col.title for col in self.bgc_cols],
-            active=[0, 1],
+            active=[0],
             name='bgc_checkbox')
 
         self.gcf_checkbox = CheckboxButtonGroup(
             labels=[col.title for col in self.gcf_cols],
-            active=[0, 1],
+            active=[0, 2],
             name='gcf_checkbox')
         
         def molfam_checkbox_callback(attr, old, new):

--- a/nplinker/templates/index.html
+++ b/nplinker/templates/index.html
@@ -164,6 +164,26 @@
                     {{ embed(roots.metcalf_info) }}
                 </div>
             </div>
+
+            <div class="row" style="margin-top: 50px;">
+                <div class="col-md-3">
+                    <strong>Molecular Families</strong>
+                    {{ embed(roots.molfam_checkbox) }}
+                </div>
+                <div class="col-md-3">
+                    <strong>Spectra</strong>
+                    {{ embed(roots.spec_checkbox) }}
+                </div>
+                <div class="col-md-3">
+                    <strong>Biosynthetic Gene Clusters</strong>
+                    {{ embed(roots.bgc_checkbox) }}
+                </div>
+                <div class="col-md-3">
+                    <strong>Gene Cluster Families</strong>
+                    {{ embed(roots.gcf_checkbox) }}
+                </div>
+            </div>
+
             <div class="row">
                 <div class="col-lg-3 met-table" id="molfam_table">
                     {{ embed(roots.table_molfams) }}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/55382553/183659854-63b66772-e3e5-485f-ae46-f6890616acfa.png)

Now the user has the option of selecting which columns to display, starting with only two of them for each table.

Some questions:
- What about the columns' names? Are they satisfactory?
- Are there any columns I can delete because we are sure they are not relevant to the user at all? For example, I think Spectrum ID is redundant (we already have ID) but I am not 100% sure. 