### PR TITLE
Clean accordion with new upload

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -109,7 +109,7 @@ def disable_tabs_and_reset_blocks(
     return False, False, False, initial_block_id, new_blocks
 
 
-def create_initial_block(block_id: str):
+def create_initial_block(block_id: str) -> dmc.Grid:
     """Create the initial block component with the given ID.
 
     Args:
@@ -238,9 +238,7 @@ def add_block(n_clicks: list[int], blocks_id: list[str]) -> list[str]:
     Input("blocks-id", "data"),
     State("blocks-container", "children"),
 )
-def display_blocks(
-    blocks_id: list[str], existing_blocks: list[dict[str, Any]]
-) -> list[dict[str, Any]]:
+def display_blocks(blocks_id: list[str], existing_blocks: list[dmc.Grid]) -> list[dmc.Grid]:
     """Display the blocks for the input block IDs.
 
     Args:

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -2,8 +2,6 @@ import uuid
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 import dash_uploader as du
-from config import GM_DROPDOWN_BGC_CLASS_OPTIONS
-from config import GM_DROPDOWN_MENU_OPTIONS
 from dash import dcc
 from dash import html
 
@@ -77,57 +75,10 @@ uploader = html.Div(
 initial_block_id = str(uuid.uuid4())
 gm_input_group = html.Div(
     [
-        dcc.Store(id="blocks-id", data=[initial_block_id]),  # Start with one block
+        dcc.Store(id="blocks-id", data=[]),  # Start with one block
         html.Div(
             id="blocks-container",
-            children=[
-                dmc.Grid(
-                    id={"type": "gm-block", "index": initial_block_id},  # Start with one block
-                    children=[
-                        dmc.GridCol(
-                            dbc.Button(
-                                [html.I(className="fas fa-plus")],
-                                id={"type": "gm-add-button", "index": initial_block_id},
-                                className="btn-primary",
-                            ),
-                            span=1,
-                        ),
-                        dmc.GridCol(
-                            dcc.Dropdown(
-                                options=GM_DROPDOWN_MENU_OPTIONS,
-                                value="GCF_ID",
-                                id={"type": "gm-dropdown-menu", "index": initial_block_id},
-                                clearable=False,
-                            ),
-                            span=6,
-                        ),
-                        dmc.GridCol(
-                            [
-                                dmc.TextInput(
-                                    id={
-                                        "type": "gm-dropdown-ids-text-input",
-                                        "index": initial_block_id,
-                                    },
-                                    placeholder="1, 2, 3, ...",
-                                    className="custom-textinput",
-                                ),
-                                dcc.Dropdown(
-                                    id={
-                                        "type": "gm-dropdown-bgc-class-dropdown",
-                                        "index": initial_block_id,
-                                    },
-                                    options=GM_DROPDOWN_BGC_CLASS_OPTIONS,
-                                    placeholder="Select one or more BGC classes",
-                                    multi=True,
-                                    style={"display": "none"},
-                                ),
-                            ],
-                            span=5,
-                        ),
-                    ],
-                    gutter="md",
-                )
-            ],
+            children=[],
         ),
     ]
 )

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -3,7 +3,7 @@ import dash
 import pytest
 from dash_uploader import UploadStatus
 from app.callbacks import add_block
-from app.callbacks import disable_tabs
+from app.callbacks import disable_tabs_and_reset_blocks
 from app.callbacks import upload_data
 from . import DATA_DIR
 
@@ -25,14 +25,20 @@ def test_upload_data():
 
 def test_disable_tabs():
     # Test with None as input
-    result = disable_tabs(None)
+    result = disable_tabs_and_reset_blocks(None)
     assert result[0] is True  # GM tab should be disabled
-    assert result[1] is True  # MG tab should be disabled
+    assert result[1] is True  # GM accordion should be disabled
+    assert result[2] is True  # MG tab should be disabled
+    assert result[3] == []  # No blocks should be displayed
+    assert result[4] == []  # No blocks should be displayed
 
     # Test with a string as input
-    result = disable_tabs(MOCK_FILE_PATH)
+    result = disable_tabs_and_reset_blocks(MOCK_FILE_PATH)
     assert result[0] is False  # GM tab should be enabled
-    assert result[1] is False  # MG tab should be enabled
+    assert result[1] is False  # GM accordion should be enabled
+    assert result[2] is False  # MG tab should be enabled
+    assert len(result[3]) == 1  # One block should be displayed
+    assert len(result[4]) == 1  # One block should be displayed
 
 
 @pytest.fixture


### PR DESCRIPTION
As described in issue #27, the initial plan was to disable the tabs and clear their contents during a new file upload. 

However, the architecture of the [dash_uploader](https://github.com/fohrloop/dash-uploader/blob/dev/docs/dash-uploader.md) module only provides access to the upload status after the process is complete, which limits the ability to perform real-time UI updates during the upload. The core issue is that the `status` variable you can access in the `du.callback` becomes actually accessible only after the file has fully uploaded. This means that actions cannot be triggered during the upload process but only after it finishes.

To work around this limitation, I decided to clear the accordion element each time a new file is uploaded, which was necessary anyway.