### PR TITLE
create selected data table

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -78,7 +78,15 @@ def upload_data(status: du.UploadStatus) -> tuple[str, str | None]:
 @app.callback(
     Output("processed-data-store", "data"), Input("file-store", "data"), prevent_initial_call=True
 )
-def process_uploaded_data(file_path):
+def process_uploaded_data(file_path: str | None) -> str | None:
+    """Process the uploaded pickle file and store the processed data.
+
+    Args:
+        file_path: Path to the uploaded pickle file.
+
+    Returns:
+        JSON string of processed data or None if processing fails.
+    """
     if file_path is None:
         return None
 
@@ -141,10 +149,7 @@ def disable_tabs_and_reset_blocks(
         file_name: The name of the uploaded file, or None if no file is uploaded.
 
     Returns:
-        A tuple containing:
-        - Boolean values for disabling gm-tab, gm-accordion-control, and mg-tab.
-        - A list with a single block ID.
-        - A list with a single block component.
+        Tuple containing boolean values for disabling tabs, styles, and new block data.
     """
     if file_name is None:
         # Disable the tabs, don't change blocks
@@ -164,7 +169,7 @@ def create_initial_block(block_id: str) -> dmc.Grid:
         block_id: A unique identifier for the block.
 
     Returns:
-        A dictionary representing a dmc.Grid component with nested elements.
+        A Grid component with nested elements.
     """
     return dmc.Grid(
         id={"type": "gm-block", "index": block_id},
@@ -213,7 +218,15 @@ def create_initial_block(block_id: str) -> dmc.Grid:
     Output("file-content-mg", "children"),
     [Input("processed-data-store", "data")],
 )
-def gm_plot(stored_data):  # noqa: D103
+def gm_plot(stored_data: str | None) -> tuple[dict, dict, str]:
+    """Create a bar plot based on the processed data.
+
+    Args:
+        stored_data: JSON string of processed data or None.
+
+    Returns:
+        Tuple containing the plot figure, style, and a status message.
+    """
     if stored_data is None:
         return {}, {"display": "none"}, "No data available"
     data = json.loads(stored_data)
@@ -376,7 +389,23 @@ def update_placeholder(
         return {"display": "none"}, {"display": "none"}, "", "", "", []
 
 
-def apply_filters(df, dropdown_menus, text_inputs, bgc_class_dropdowns):
+def apply_filters(
+    df: pd.DataFrame,
+    dropdown_menus: list[str],
+    text_inputs: list[str],
+    bgc_class_dropdowns: list[list[str]],
+) -> pd.DataFrame:
+    """Apply filters to the DataFrame based on user inputs.
+
+    Args:
+        df: The input DataFrame.
+        dropdown_menus: List of selected dropdown menu options.
+        text_inputs: List of text inputs for GCF IDs.
+        bgc_class_dropdowns: List of selected BGC classes.
+
+    Returns:
+        Filtered DataFrame.
+    """
     masks = []
 
     for menu, text_input, bgc_classes in zip(dropdown_menus, text_inputs, bgc_class_dropdowns):
@@ -408,7 +437,23 @@ def apply_filters(df, dropdown_menus, text_inputs, bgc_class_dropdowns):
     Input({"type": "gm-dropdown-ids-text-input", "index": ALL}, "value"),
     Input({"type": "gm-dropdown-bgc-class-dropdown", "index": ALL}, "value"),
 )
-def update_datatable(processed_data, dropdown_menus, text_inputs, bgc_class_dropdowns):
+def update_datatable(
+    processed_data: str,
+    dropdown_menus: list[str],
+    text_inputs: list[str],
+    bgc_class_dropdowns: list[list[str]],
+) -> tuple[list[dict], list[dict], dict]:
+    """Update the DataTable based on processed data and applied filters.
+
+    Args:
+        processed_data : JSON string of processed data.
+        dropdown_menus: List of selected dropdown menu options.
+        text_inputs: List of text inputs for GCF IDs.
+        bgc_class_dropdowns: List of selected BGC classes.
+
+    Returns:
+        Tuple containing table data, column definitions, and style.
+    """
     if processed_data is None:
         return [], [], {"display": "none"}
 
@@ -471,8 +516,16 @@ def toggle_selection(
     Input("gm-table", "derived_virtual_data"),
     Input("gm-table", "derived_virtual_selected_rows"),
 )
-def select_rows(rows, selected_rows):
-    """Display the total number of rows and the number of selected rows in the table."""
+def select_rows(rows: list[dict[str, Any]], selected_rows: list[int] | None) -> tuple[str, str]:
+    """Display the total number of rows and the number of selected rows in the table.
+
+    Args:
+        rows: List of row data from the DataTable.
+        selected_rows: Indices of selected rows.
+
+    Returns:
+        Strings describing total rows and selected rows.
+    """
     if not rows:
         return "No data available.", "No rows selected."
 

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -475,7 +475,7 @@ def update_datatable(
 
 @app.callback(
     [Output("gm-table", "selected_rows")],
-    [Input("gm-rows-selection-button", "n_clicks")],
+    [Input("gm-rows-selection-checkbox", "value")],
     [
         State("gm-table", "data"),
         State("gm-table", "derived_virtual_data"),
@@ -483,12 +483,12 @@ def update_datatable(
     ],
 )
 def toggle_selection(
-    n_clicks: int, original_rows: list, filtered_rows: list | None, selected_rows: list
+    value: int, original_rows: list, filtered_rows: list | None, selected_rows: list
 ) -> list:
     """Toggle between selecting all rows and deselecting all rows in a Dash DataTable.
 
     Args:
-        n_clicks: Number of button clicks (unused).
+        value: Checkbox selected.
         original_rows: All rows in the table.
         filtered_rows: Rows visible after filtering.
         selected_rows: Currently selected row indices.

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -181,7 +181,7 @@ def create_initial_block(block_id: str) -> dmc.Grid:
                     id={"type": "gm-add-button", "index": block_id},
                     className="btn-primary",
                 ),
-                span=1,
+                span=2,
             ),
             dmc.GridCol(
                 dcc.Dropdown(
@@ -190,7 +190,7 @@ def create_initial_block(block_id: str) -> dmc.Grid:
                     id={"type": "gm-dropdown-menu", "index": block_id},
                     clearable=False,
                 ),
-                span=6,
+                span=4,
             ),
             dmc.GridCol(
                 [
@@ -206,7 +206,7 @@ def create_initial_block(block_id: str) -> dmc.Grid:
                         style={"display": "none"},
                     ),
                 ],
-                span=5,
+                span=6,
             ),
         ],
         gutter="md",
@@ -306,12 +306,31 @@ def display_blocks(blocks_id: list[str], existing_blocks: list[dmc.Grid]) -> lis
             id={"type": "gm-block", "index": new_block_id},
             children=[
                 dmc.GridCol(
-                    dbc.Button(
-                        [html.I(className="fas fa-plus")],
-                        id={"type": "gm-add-button", "index": new_block_id},
-                        className="btn-primary",
+                    html.Div(
+                        [
+                            dbc.Button(
+                                [html.I(className="fas fa-plus")],
+                                id={"type": "gm-add-button", "index": new_block_id},
+                                className="btn-primary",
+                            ),
+                            html.Label(
+                                "OR",
+                                id={"type": "gm-or-label", "index": new_block_id},
+                                className="ms-2 px-2 py-1 rounded",
+                                style={
+                                    "color": "green",
+                                    "backgroundColor": "#f0f0f0",
+                                    "display": "inline-block",
+                                    "position": "absolute",
+                                    "left": "50px",  # Adjust based on button width
+                                    "top": "50%",
+                                    "transform": "translateY(-50%)",
+                                },
+                            ),
+                        ],
+                        style={"position": "relative", "height": "38px"},
                     ),
-                    span=1,
+                    span=2,
                 ),
                 dmc.GridCol(
                     dcc.Dropdown(
@@ -320,7 +339,7 @@ def display_blocks(blocks_id: list[str], existing_blocks: list[dmc.Grid]) -> lis
                         id={"type": "gm-dropdown-menu", "index": new_block_id},
                         clearable=False,
                     ),
-                    span=6,
+                    span=4,
                 ),
                 dmc.GridCol(
                     [
@@ -336,16 +355,21 @@ def display_blocks(blocks_id: list[str], existing_blocks: list[dmc.Grid]) -> lis
                             style={"display": "none"},
                         ),
                     ],
-                    span=5,
+                    span=6,
                 ),
             ],
             gutter="md",
         )
 
-        # Hide the add button on the previous last block
-        existing_blocks[-1]["props"]["children"][0]["props"]["children"]["props"]["style"] = {
-            "display": "none"
-        }
+        # Hide the add button and OR label on the previous last block
+        if len(existing_blocks) == 1:
+            existing_blocks[-1]["props"]["children"][0]["props"]["children"]["props"]["style"] = {
+                "display": "none"
+            }
+        else:
+            existing_blocks[-1]["props"]["children"][0]["props"]["children"]["props"]["children"][
+                0
+            ]["props"]["style"] = {"display": "none"}
 
         return existing_blocks + [new_block]
     return existing_blocks

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -3,6 +3,7 @@ import os
 import pickle
 import tempfile
 import uuid
+from pathlib import Path
 from typing import Any
 import dash
 import dash_bootstrap_components as dbc
@@ -78,7 +79,7 @@ def upload_data(status: du.UploadStatus) -> tuple[str, str | None]:
 @app.callback(
     Output("processed-data-store", "data"), Input("file-store", "data"), prevent_initial_call=True
 )
-def process_uploaded_data(file_path: str | None) -> str | None:
+def process_uploaded_data(file_path: Path | str | None) -> str | None:
     """Process the uploaded pickle file and store the processed data.
 
     Args:
@@ -141,17 +142,17 @@ def process_uploaded_data(file_path: str | None) -> str | None:
     prevent_initial_call=True,
 )
 def disable_tabs_and_reset_blocks(
-    file_name: str | None,
+    file_path: Path | str | None,
 ) -> tuple[bool, bool, dict, dict[str, str], bool, list[str], list[dmc.Grid]]:
     """Manage tab states and reset blocks based on file upload status.
 
     Args:
-        file_name: The name of the uploaded file, or None if no file is uploaded.
+        file_path: The name of the uploaded file, or None if no file is uploaded.
 
     Returns:
         Tuple containing boolean values for disabling tabs, styles, and new block data.
     """
-    if file_name is None:
+    if file_path is None:
         # Disable the tabs, don't change blocks
         return True, True, {}, {"display": "block"}, True, [], []
 

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -441,7 +441,7 @@ def apply_filters(
                 masks.append(mask)
         elif menu == "BGC_CLASS" and bgc_classes:
             mask = df["BGC Classes"].apply(
-                lambda x: any(bgc_class in x for bgc_class in bgc_classes)
+                lambda x: any(bc.lower() in [y.lower() for y in x] for bc in bgc_classes)
             )
             masks.append(mask)
 

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -439,7 +439,7 @@ def apply_filters(
     Input({"type": "gm-dropdown-bgc-class-dropdown", "index": ALL}, "value"),
 )
 def update_datatable(
-    processed_data: str,
+    processed_data: str | None,
     dropdown_menus: list[str],
     text_inputs: list[str],
     bgc_class_dropdowns: list[list[str]],
@@ -483,7 +483,7 @@ def update_datatable(
     ],
 )
 def toggle_selection(
-    n_clicks: int, original_rows: list, filtered_rows: list, selected_rows: list
+    n_clicks: int, original_rows: list, filtered_rows: list | None, selected_rows: list
 ) -> list:
     """Toggle between selecting all rows and deselecting all rows in a Dash DataTable.
 

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -218,7 +218,7 @@ def create_initial_block(block_id: str) -> dmc.Grid:
     Output("file-content-mg", "children"),
     [Input("processed-data-store", "data")],
 )
-def gm_plot(stored_data: str | None) -> tuple[dict, dict, str]:
+def gm_plot(stored_data: str | None) -> tuple[dict | go.Figure, dict, str]:
     """Create a bar plot based on the processed data.
 
     Args:

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -97,7 +97,7 @@ def process_uploaded_data(file_path: str | None) -> str | None:
         # Extract and process the necessary data
         bgcs, gcfs, *_ = data
 
-        def process_bgc_class(bgc_class):
+        def process_bgc_class(bgc_class: tuple[str, ...] | None) -> list[str]:
             if bgc_class is None:
                 return ["Unknown"]
             return list(bgc_class)  # Convert tuple to list
@@ -105,7 +105,7 @@ def process_uploaded_data(file_path: str | None) -> str | None:
         # Create a dictionary to map BGC to its class
         bgc_to_class = {bgc.id: process_bgc_class(bgc.mibig_bgc_class) for bgc in bgcs}
 
-        processed_data = {"n_bgcs": {}, "gcf_data": []}
+        processed_data: dict[str, Any] = {"n_bgcs": {}, "gcf_data": []}
 
         for gcf in gcfs:
             gcf_bgc_classes = [cls for bgc in gcf.bgcs for cls in bgc_to_class[bgc.id]]

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -351,12 +351,51 @@ df = pd.DataFrame(
 
 
 @app.callback(
+    [Output("gm-table", "selected_rows")],
+    [Input("gm-rows-selection-button", "n_clicks")],
+    [
+        State("gm-table", "data"),
+        State("gm-table", "derived_virtual_data"),
+        State("gm-table", "derived_virtual_selected_rows"),
+    ],
+)
+def toggle_selection(
+    n_clicks: int, original_rows: list, filtered_rows: list, selected_rows: list
+) -> list:
+    """Toggle between selecting all rows and deselecting all rows in a Dash DataTable.
+
+    Args:
+        n_clicks: Number of button clicks (unused).
+        original_rows: All rows in the table.
+        filtered_rows: Rows visible after filtering.
+        selected_rows: Currently selected row indices.
+
+    Returns:
+        Indices of selected rows after toggling.
+
+    Raises:
+        PreventUpdate: If filtered_rows is None.
+    """
+    if filtered_rows is None:
+        raise dash.exceptions.PreventUpdate
+
+    if not selected_rows or len(selected_rows) < len(filtered_rows):
+        # If no rows are selected or not all rows are selected, select all filtered rows
+        selected_ids = [row for row in filtered_rows]
+        return [[i for i, row in enumerate(original_rows) if row in selected_ids]]
+    else:
+        # If all rows are selected, deselect all
+        return [[]]
+
+
+@app.callback(
     Output("gm-table-output1", "children"),
     Output("gm-table-output2", "children"),
     Input("gm-table", "derived_virtual_data"),
     Input("gm-table", "derived_virtual_selected_rows"),
 )
 def select_rows(rows, selected_rows):
+    """Display the total number of rows and the number of selected rows in the table."""
     if not rows:
         return "No data available.", "No rows selected."
 

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -475,7 +475,7 @@ def update_datatable(
 
 @app.callback(
     [Output("gm-table", "selected_rows")],
-    [Input("gm-rows-selection-checkbox", "value")],
+    [Input("select-all-checkbox", "value")],
     [
         State("gm-table", "data"),
         State("gm-table", "derived_virtual_data"),

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -131,10 +131,10 @@ gm_table = dbc.Card(
                     columns=[],  # Start with empty columns
                     data=[],  # Start with empty data
                     editable=False,
-                    filter_action="native",
+                    filter_action="none",
                     sort_action="none",
                     sort_mode="multi",
-                    column_selectable="single",
+                    column_selectable=False,
                     row_deletable=False,
                     row_selectable="multi",
                     selected_columns=[],
@@ -148,6 +148,17 @@ gm_table = dbc.Card(
                         "fontWeight": "bold",
                         "color": "white",
                     },
+                    style_data={
+                        "border": "1px solid #ddd"  # Ensure data cells have borders
+                    },
+                    style_data_conditional=[
+                        {
+                            "if": {"state": "selected"},
+                            "backgroundColor": "white",  # Light gray background for selected rows
+                            "border": "1px solid #ddd",  # Preserve borders for selected rows
+                        }
+                    ],
+                    style_cell_conditional=[{"if": {"column_id": "selector"}, "width": "30px"}],
                 ),
             ],
             id="gm-table-card-body",

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -115,9 +115,25 @@ df = pd.DataFrame(
 ## Table
 gm_table = dbc.Card(
     [
-        dbc.CardHeader("Data", id="gm-table-card-header", style={"color": "#888888"}),
+        dbc.CardHeader(
+            [
+                "Data",
+            ],
+            id="gm-table-card-header",
+            style={"color": "#888888"},
+        ),
         dbc.CardBody(
             [
+                dbc.Row(
+                    dbc.Col(
+                        dbc.Button(
+                            "Select/deselect all",
+                            id="gm-rows-selection-button",
+                            className="mb-3",
+                        ),
+                        className="text-center",
+                    )
+                ),
                 dash_table.DataTable(
                     id="gm-table",
                     columns=[

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -2,7 +2,6 @@ import uuid
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 import dash_uploader as du
-import pandas as pd
 from dash import dash_table
 from dash import dcc
 from dash import html
@@ -67,6 +66,7 @@ uploader = html.Div(
             )
         ),
         dcc.Store(id="file-store"),  # Store to keep the file contents
+        dcc.Store(id="processed-data-store"),  # Store to keep the processed data
     ],
     className="p-5 ml-5 mr-5",
 )
@@ -105,14 +105,6 @@ gm_accordion = dmc.Accordion(
 # gm graph
 gm_graph = dcc.Graph(id="gm-graph", className="mt-5 mb-3", style={"display": "none"})
 # gm_table
-## Sample data
-df = pd.DataFrame(
-    {
-        "GCF ID": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
-        "# BGC": ["3", "1", "10", "6", "3", "1", "10", "6", "3", "1", "10", "6"],
-    }
-)
-## Table
 gm_table = dbc.Card(
     [
         dbc.CardHeader(
@@ -136,11 +128,8 @@ gm_table = dbc.Card(
                 ),
                 dash_table.DataTable(
                     id="gm-table",
-                    columns=[
-                        {"name": i, "id": i, "deletable": False, "selectable": False}
-                        for i in df.columns
-                    ],
-                    data=df.to_dict("records"),
+                    columns=[],  # Start with empty columns
+                    data=[],  # Start with empty data
                     editable=False,
                     filter_action="native",
                     sort_action="none",

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -2,6 +2,8 @@ import uuid
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 import dash_uploader as du
+import pandas as pd
+from dash import dash_table
 from dash import dcc
 from dash import html
 
@@ -102,11 +104,60 @@ gm_accordion = dmc.Accordion(
 )
 # gm graph
 gm_graph = dcc.Graph(id="gm-graph", className="mt-5 mb-3", style={"display": "none"})
+# gm_table
+## Sample data
+df = pd.DataFrame(
+    {
+        "GCF ID": ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"],
+        "# BGC": ["3", "1", "10", "6", "3", "1", "10", "6", "3", "1", "10", "6"],
+    }
+)
+## Table
+gm_table = dbc.Card(
+    [
+        dbc.CardHeader("Select data", id="gm-table-card-header", style={"color": "#888888"}),
+        dbc.CardBody(
+            [
+                dash_table.DataTable(
+                    id="gm-table",
+                    columns=[
+                        {"name": i, "id": i, "deletable": False, "selectable": False}
+                        for i in df.columns
+                    ],
+                    data=df.to_dict("records"),
+                    editable=False,
+                    filter_action="native",
+                    sort_action="none",
+                    sort_mode="multi",
+                    column_selectable="single",
+                    row_deletable=False,
+                    row_selectable="multi",
+                    selected_columns=[],
+                    selected_rows=[],
+                    page_action="native",
+                    page_current=0,
+                    page_size=10,
+                    style_cell={"textAlign": "left", "padding": "5px"},
+                    style_header={
+                        "backgroundColor": "#FF6E42",
+                        "fontWeight": "bold",
+                        "color": "white",
+                    },
+                ),
+            ],
+            id="gm-table-card-body",
+            style={"display": "none"},  # Initially hide the CardBody
+        ),
+        html.Div(id="gm-table-output1", className="p-4"),
+        html.Div(id="gm-table-output2", className="p-4"),
+    ]
+)
 # gm tab content
 gm_content = dbc.Row(
     [
-        dbc.Col(gm_accordion, width=10, className="mx-auto"),
+        dbc.Col(gm_accordion, width=10, className="mx-auto dbc"),
         dbc.Col(gm_graph, width=10, className="mx-auto"),
+        dbc.Col(gm_table, width=10, className="mx-auto"),
     ]
 )
 # mg tab content
@@ -145,5 +196,5 @@ tabs = dbc.Row(
 
 def create_layout():  # noqa: D103
     return dmc.MantineProvider(
-        [dbc.Container([navbar, uploader, tabs], fluid=True, className="p-0 dbc")]
+        [dbc.Container([navbar, uploader, tabs], fluid=True, className="p-0")]
     )

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -116,15 +116,18 @@ gm_table = dbc.Card(
         ),
         dbc.CardBody(
             [
-                dbc.Row(
-                    dbc.Col(
-                        dcc.Checklist(
-                            options={"disabled": ""},
-                            id="gm-rows-selection-checkbox",
-                            className="mb-3",
-                        ),
-                        className="text-center",
-                    )
+                html.Div(
+                    dcc.Checklist(
+                        options={"disabled": ""},
+                        id="select-all-checkbox",
+                        style={
+                            "position": "absolute",
+                            "top": "4px",
+                            "left": "10px",
+                            "zIndex": "1000",
+                        },
+                    ),
+                    style={"position": "relative", "height": "0px"},
                 ),
                 dash_table.DataTable(
                     id="gm-table",

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -118,9 +118,9 @@ gm_table = dbc.Card(
             [
                 dbc.Row(
                     dbc.Col(
-                        dbc.Button(
-                            "Select/deselect all",
-                            id="gm-rows-selection-button",
+                        dcc.Checklist(
+                            options={"disabled": ""},
+                            id="gm-rows-selection-checkbox",
                             className="mb-3",
                         ),
                         className="text-center",

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -115,7 +115,7 @@ df = pd.DataFrame(
 ## Table
 gm_table = dbc.Card(
     [
-        dbc.CardHeader("Select data", id="gm-table-card-header", style={"color": "#888888"}),
+        dbc.CardHeader("Data", id="gm-table-card-header", style={"color": "#888888"}),
         dbc.CardBody(
             [
                 dash_table.DataTable(

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,3 @@ dash_bootstrap_templates
 numpy
 dash-uploader==0.7.0a1
 packaging==21.3.0
-python-dotenv

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ dash_bootstrap_templates
 numpy
 dash-uploader==0.7.0a1
 packaging==21.3.0
+python-dotenv

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,6 @@
 import uuid
 import dash
+import dash_mantine_components as dmc
 import pytest
 from dash_uploader import UploadStatus
 from app.callbacks import add_block
@@ -23,30 +24,41 @@ def test_upload_data():
     assert path_string == str(MOCK_FILE_PATH)
 
 
-def test_disable_tabs():
-    # Test with None as input
-    result = disable_tabs_and_reset_blocks(None)
-    assert result[0] is True  # GM tab should be disabled
-    assert result[1] is True  # GM accordion should be disabled
-    assert result[2] is True  # MG tab should be disabled
-    assert result[3] == []  # No blocks should be displayed
-    assert result[4] == []  # No blocks should be displayed
-
-    # Test with a string as input
-    result = disable_tabs_and_reset_blocks(MOCK_FILE_PATH)
-    assert result[0] is False  # GM tab should be enabled
-    assert result[1] is False  # GM accordion should be enabled
-    assert result[2] is False  # MG tab should be enabled
-    assert len(result[3]) == 1  # One block should be displayed
-    assert len(result[4]) == 1  # One block should be displayed
-
-
 @pytest.fixture
 def mock_uuid(monkeypatch):
     def mock_uuid4():
         return "test-uuid"
 
     monkeypatch.setattr(uuid, "uuid4", mock_uuid4)
+
+
+def test_disable_tabs(mock_uuid):
+    # Test with None as input
+    result = disable_tabs_and_reset_blocks(None)
+    assert result == (True, True, {}, {"display": "block"}, True, [], [])
+
+    # Test with a string as input
+    result = disable_tabs_and_reset_blocks(MOCK_FILE_PATH)
+
+    # Unpack the result for easier assertion
+    (
+        gm_tab_disabled,
+        gm_accordion_disabled,
+        table_header_style,
+        table_body_style,
+        mg_tab_disabled,
+        block_ids,
+        blocks,
+    ) = result
+
+    assert gm_tab_disabled is False
+    assert gm_accordion_disabled is False
+    assert table_header_style == {}
+    assert table_body_style == {"display": "block"}
+    assert mg_tab_disabled is False
+    assert block_ids == ["test-uuid"]
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], dmc.Grid)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -3,16 +3,42 @@ import uuid
 from pathlib import Path
 import dash
 import dash_mantine_components as dmc
+import pandas as pd
 import pytest
 from dash_uploader import UploadStatus
 from app.callbacks import add_block
+from app.callbacks import apply_filters
 from app.callbacks import disable_tabs_and_reset_blocks
 from app.callbacks import process_uploaded_data
+from app.callbacks import select_rows
+from app.callbacks import toggle_selection
+from app.callbacks import update_datatable
 from app.callbacks import upload_data
 from . import DATA_DIR
 
 
 MOCK_FILE_PATH = DATA_DIR / "mock_obj_data.pkl"
+
+
+@pytest.fixture
+def mock_uuid(monkeypatch):
+    def mock_uuid4():
+        return "test-uuid"
+
+    monkeypatch.setattr(uuid, "uuid4", mock_uuid4)
+
+
+@pytest.fixture
+def processed_data():
+    # Use the actual process_uploaded_data function to get the processed data
+    return process_uploaded_data(MOCK_FILE_PATH)
+
+
+@pytest.fixture
+def sample_df(processed_data):
+    # Convert the processed data back to a DataFrame
+    data = json.loads(processed_data)
+    return pd.DataFrame(data["gcf_data"])
 
 
 def test_upload_data():
@@ -25,43 +51,6 @@ def test_upload_data():
     # Check the result
     assert upload_string == f"Successfully uploaded: {MOCK_FILE_PATH.name} [5.39 MB]"
     assert path_string == str(MOCK_FILE_PATH)
-
-
-@pytest.fixture
-def mock_uuid(monkeypatch):
-    def mock_uuid4():
-        return "test-uuid"
-
-    monkeypatch.setattr(uuid, "uuid4", mock_uuid4)
-
-
-def test_disable_tabs(mock_uuid):
-    # Test with None as input
-    result = disable_tabs_and_reset_blocks(None)
-    assert result == (True, True, {}, {"display": "block"}, True, [], [])
-
-    # Test with a string as input
-    result = disable_tabs_and_reset_blocks(MOCK_FILE_PATH)
-
-    # Unpack the result for easier assertion
-    (
-        gm_tab_disabled,
-        gm_accordion_disabled,
-        table_header_style,
-        table_body_style,
-        mg_tab_disabled,
-        block_ids,
-        blocks,
-    ) = result
-
-    assert gm_tab_disabled is False
-    assert gm_accordion_disabled is False
-    assert table_header_style == {}
-    assert table_body_style == {"display": "block"}
-    assert mg_tab_disabled is False
-    assert block_ids == ["test-uuid"]
-    assert len(blocks) == 1
-    assert isinstance(blocks[0], dmc.Grid)
 
 
 @pytest.mark.parametrize("input_path", [None, Path("non_existent_file.pkl")])
@@ -123,6 +112,35 @@ def test_process_uploaded_data_structure():
         assert isinstance(gcf["BGC Classes"], list)
 
 
+def test_disable_tabs(mock_uuid):
+    # Test with None as input
+    result = disable_tabs_and_reset_blocks(None)
+    assert result == (True, True, {}, {"display": "block"}, True, [], [])
+
+    # Test with a string as input
+    result = disable_tabs_and_reset_blocks(MOCK_FILE_PATH)
+
+    # Unpack the result for easier assertion
+    (
+        gm_tab_disabled,
+        gm_accordion_disabled,
+        table_header_style,
+        table_body_style,
+        mg_tab_disabled,
+        block_ids,
+        blocks,
+    ) = result
+
+    assert gm_tab_disabled is False
+    assert gm_accordion_disabled is False
+    assert table_header_style == {}
+    assert table_body_style == {"display": "block"}
+    assert mg_tab_disabled is False
+    assert block_ids == ["test-uuid"]
+    assert len(blocks) == 1
+    assert isinstance(blocks[0], dmc.Grid)
+
+
 @pytest.mark.parametrize(
     "n_clicks, initial_blocks, expected_result",
     [
@@ -142,3 +160,64 @@ def test_add_block(mock_uuid, n_clicks, initial_blocks, expected_result):
     else:
         with expected_result:
             add_block(n_clicks, initial_blocks)
+
+
+def test_apply_filters(sample_df):
+    # Test GCF_ID filter
+    gcf_ids = sample_df["GCF ID"].iloc[:2].tolist()
+    filtered_df = apply_filters(sample_df, ["GCF_ID"], [",".join(gcf_ids)], [[]])
+    assert len(filtered_df) == 2
+    assert set(filtered_df["GCF ID"]) == set(gcf_ids)
+
+    # Test BGC_CLASS filter
+    bgc_class = sample_df["BGC Classes"].iloc[0][0]  # Get the first BGC class from the first row
+    filtered_df = apply_filters(sample_df, ["BGC_CLASS"], [""], [[bgc_class]])
+    assert len(filtered_df) > 0
+    assert all(bgc_class in classes for classes in filtered_df["BGC Classes"])
+
+    # Test no filter
+    filtered_df = apply_filters(sample_df, [], [], [])
+    assert len(filtered_df) == len(sample_df)
+
+
+def test_update_datatable(processed_data):
+    result = update_datatable(processed_data, [], [], [])
+    assert len(result) == 3
+    assert isinstance(result[0], list)  # data
+    assert isinstance(result[1], list)  # columns
+    assert result[2] == {"display": "block"}  # style
+
+    # Test with None input
+    result = update_datatable(None, [], [], [])
+    assert result == ([], [], {"display": "none"})
+
+
+def test_toggle_selection(sample_df):
+    original_rows = sample_df.to_dict("records")
+    filtered_rows = original_rows[:2]
+
+    # Test selecting all rows
+    result = toggle_selection(1, original_rows, filtered_rows, [])
+    assert result == [[0, 1]]
+
+    # Test deselecting all rows
+    result = toggle_selection(1, original_rows, filtered_rows, [0, 1])
+    assert result == [[]]
+
+    # Test with None filtered_rows
+    with pytest.raises(dash.exceptions.PreventUpdate):
+        toggle_selection(1, original_rows, None, [])
+
+
+def test_select_rows(sample_df):
+    rows = sample_df.to_dict("records")
+    selected_rows = [0, 2]
+
+    output1, output2 = select_rows(rows, selected_rows)
+    assert output1 == f"Total rows: {len(rows)}"
+    assert output2.startswith(f"Selected rows: {len(selected_rows)}\nSelected GCF IDs: ")
+
+    # Test with no rows
+    output1, output2 = select_rows([], None)
+    assert output1 == "No data available."
+    assert output2 == "No rows selected."


### PR DESCRIPTION
With this PR, an [interactive DataTable](https://dash.plotly.com/datatable/interactivity?_gl=1*1lrgg5y*_gcl_au*MTA3NDU2Nzg4NS4xNzE5NTY4OTM4*_ga*NTk3MjAxNTEzLjE3MTA1MTgwNjk.*_ga_6G7EE0JNSC*MTcyMzYzOTk2Mi40NS4xLjE3MjM2NDAzMjcuNTEuMC4w) displaying the data filtered via the genomics filter is added.
- The filters are applied live.
- The filters are put in a OR operation. 
- Multiple rows can be selected. 
- A practical button for selecting/deselecting all rows has been added. 
- The pages' numbering is automatically handled for bigger datasets. 
- Two output placeholders have been placed after the DataTable but they will be removed in the next step, when the scoring part will be inserted. Now they are useful for dev purposes. 
- Now instead of storing the uploaded file path, we store a json file which is lighter and contain only the information we need so far. Otherwise, in each callback that uses the data we would have to upload the .pkl file again. 
- Tests have been added.

The hyperlinks we designed (see #21) are still missing, but I think that this PR can already be reviewed before going on and finalizing it. 