### PR TITLE
fix: efficiency and layout, pre-workshop

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -2209,8 +2209,8 @@ def generate_excel(n_clicks, table_data, detailed_data, tab_prefix):
     Args:
         n_clicks: Number of clicks on the download button.
         table_data: Data from the results table.
-        tab_prefix: Tab prefix ('gm' or 'mg').
         detailed_data: Detailed data for each row in the table.
+        tab_prefix: Tab prefix ('gm' or 'mg').
 
     Returns:
         Tuple containing the download component, alert visibility, alert message, and spinner state.
@@ -2228,9 +2228,15 @@ def generate_excel(n_clicks, table_data, detailed_data, tab_prefix):
             # Sheet 2: Detailed data
             detailed_data_list = []
 
-            for row in table_data:
+            # Get unique primary IDs to avoid redundant processing
+            if tab_prefix == "gm":
+                unique_primary_ids = {row["GCF ID"] for row in table_data}
+            else:  # MG
+                unique_primary_ids = {row["MF ID"] for row in table_data}
+
+            # Process each unique primary ID only once
+            for primary_id in unique_primary_ids:
                 if tab_prefix == "gm":
-                    primary_id = row["GCF ID"]
                     detail = detailed_data.get(str(primary_id), {})
 
                     if not detail:
@@ -2288,7 +2294,6 @@ def generate_excel(n_clicks, table_data, detailed_data, tab_prefix):
                         }
                         detailed_data_list.append(detail_row)
                 else:  # MG
-                    primary_id = row["MF ID"]
                     detail = detailed_data.get(str(primary_id), {})
 
                     if not detail:

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -1804,10 +1804,10 @@ def update_results_datatable(
     triggered_id = ctx.triggered_id
 
     if triggered_id in [f"{prefix}-table-select-all-checkbox", f"{prefix}-table"]:
-        return "", False, [], [], {"display": "none"}, {"color": "#888888"}, True, None
+        return "", False, [], [], {"display": "none"}, {"color": "#888888"}, True, None, {}
 
     if n_clicks is None:
-        return "", False, [], [], {"display": "none"}, {"color": "#888888"}, True, None
+        return "", False, [], [], {"display": "none"}, {"color": "#888888"}, True, None, {}
 
     if not selected_rows:
         return (
@@ -1819,6 +1819,7 @@ def update_results_datatable(
             {"color": "#888888"},
             True,
             None,
+            {},
         )
 
     if not virtual_data:
@@ -1831,6 +1832,7 @@ def update_results_datatable(
             {"color": "#888888"},
             True,
             None,
+            {},
         )
 
     try:
@@ -1845,6 +1847,7 @@ def update_results_datatable(
                 {"color": "#888888"},
                 True,
                 None,
+                {},
             )
 
         links_data = links_data[f"{prefix}_data"]
@@ -1863,7 +1866,6 @@ def update_results_datatable(
             id_field = "gcf_id"
             item_field = "spectrum"
             score_field = "score"
-            tooltip_field = "spectrum_ids_str"
         else:  # MG
             # Get selected MF IDs
             selected_items = {
@@ -1884,7 +1886,6 @@ def update_results_datatable(
             id_field = "mf_id"
             item_field = "gcf"
             score_field = "score"
-            tooltip_field = "gcf_ids_str"
 
         # Convert links data to DataFrame
         links_df = pd.DataFrame(links_data)
@@ -1905,10 +1906,12 @@ def update_results_datatable(
                 {"color": "#888888"},
                 True,
                 None,
+                {},
             )
 
         # Prepare for results using vectorized operations
         results = []
+        detailed_data = {}  # Only store additional data needed for Excel export
 
         # Group by the ID field
         for item_id, group in filtered_df.groupby(id_field):
@@ -1929,6 +1932,23 @@ def update_results_datatable(
             if prefix == "gm":
                 # Convert to dictionary format for faster processing
                 top_items_dict = top_items.to_dict("records")
+
+                # Only create the extra data field once per GCF ID
+                detailed_data[str(item_id)] = {
+                    "spectrum_ids_str": "|".join([str(s.get("id", "")) for s in group[item_field]]),
+                    "spectrum_mf_ids_str": "|".join(
+                        [str(s.get("mf_id", "None")) for s in group[item_field]]
+                    ),
+                    "spectrum_scores_str": "|".join(
+                        [str(score) for score in group[score_field].tolist()]
+                    ),
+                    "spectrum_mz_str": "|".join(
+                        [str(s.get("precursor_mz", "None")) for s in group[item_field]]
+                    ),
+                    "spectrum_gnps_id_str": "|".join(
+                        [str(s.get("gnps_id", "None")) for s in group[item_field]]
+                    ),
+                }
 
                 # Create results for each top item
                 for top_item in top_items_dict:
@@ -1958,27 +1978,36 @@ def update_results_datatable(
                         else float("nan"),
                         "MiBIG IDs": selected_items[item_id]["MiBIG IDs"],
                         "BGC Classes": selected_items[item_id]["BGC Classes"],
-                        # Store all spectrum data for later use
-                        "spectrum_ids_str": "|".join(
-                            [str(s.get("id", "")) for s in group[item_field]]
-                        ),
-                        "spectrum_mf_ids_str": "|".join(
-                            [str(s.get("mf_id", "None")) for s in group[item_field]]
-                        ),
-                        "spectrum_scores_str": "|".join(
-                            [str(score) for score in group[score_field].tolist()]
-                        ),
-                        "spectrum_mz_str": "|".join(
-                            [str(s.get("precursor_mz", "None")) for s in group[item_field]]
-                        ),
-                        "spectrum_gnps_id_str": "|".join(
-                            [str(s.get("gnps_id", "None")) for s in group[item_field]]
-                        ),
                     }
                     results.append(result)
             else:  # MG
                 # Convert to dictionary format for faster processing
                 top_items_dict = top_items.to_dict("records")
+
+                # Only create the extra data field once per MF ID
+                detailed_data[str(item_id)] = {
+                    "gcf_ids_str": "|".join([str(gcf.get("id", "")) for gcf in group[item_field]]),
+                    "gcf_scores_str": "|".join(
+                        [str(score) for score in group[score_field].tolist()]
+                    ),
+                    "gcf_bgc_classes_str": "|".join(
+                        [
+                            ", ".join(
+                                {item for sublist in gcf.get("BGC Classes", []) for item in sublist}
+                            )
+                            for gcf in group[item_field]
+                        ]
+                    ),
+                    "gcf_bgc_ids_str": "|".join(
+                        [
+                            ", ".join([str(bgc_id) for bgc_id in gcf.get("BGC IDs", [])])
+                            for gcf in group[item_field]
+                        ]
+                    ),
+                    "gcf_num_bgcs_str": "|".join(
+                        [str(gcf.get("# BGCs", 0)) for gcf in group[item_field]]
+                    ),
+                }
 
                 # Create results for each top item
                 for top_item in top_items_dict:
@@ -2002,91 +2031,68 @@ def update_results_datatable(
                             }
                         ),
                         "Top GCF Score": round(top_item.get(score_field, float("nan")), 4),
-                        # Store all GCF data for later use
-                        "gcf_ids_str": "|".join(
-                            [str(gcf.get("id", "")) for gcf in group[item_field]]
-                        ),
-                        "gcf_scores_str": "|".join(
-                            [str(score) for score in group[score_field].tolist()]
-                        ),
-                        "gcf_bgc_classes_str": "|".join(
-                            [
-                                ", ".join(
-                                    {
-                                        item
-                                        for sublist in gcf.get("BGC Classes", [])
-                                        for item in sublist
-                                    }
-                                )
-                                for gcf in group[item_field]
-                            ]
-                        ),
-                        "gcf_bgc_ids_str": "|".join(
-                            [
-                                ", ".join([str(bgc_id) for bgc_id in gcf.get("BGC IDs", [])])
-                                for gcf in group[item_field]
-                            ]
-                        ),
-                        "gcf_num_bgcs_str": "|".join(
-                            [str(gcf.get("# BGCs", 0)) for gcf in group[item_field]]
-                        ),
                     }
                     results.append(result)
-        # Prepare tooltip data
+
         tooltip_data = []
+        # Only generate tooltips if we have a reasonable number of rows
         if len(results) > MAX_TOOLTIP_ROWS:
             alert_message = f"Tooltips disabled for performance (showing {len(results)} rows)."
-            return (
-                alert_message,
-                True,
-                results,
-                tooltip_data,
-                {"display": "block"},
-                {},
-                False,
-                None,
-            )
         else:
+            # Prepare tooltip data
+            alert_message = ""
             for result in results:
-                ids = result[tooltip_field].split("|") if result[tooltip_field] else []
-                scores = (
-                    [
-                        float(s)
-                        for s in result[
-                            f"{item_field if prefix == 'gm' else 'gcf'}_scores_str"
-                        ].split("|")
-                    ]
-                    if result[f"{item_field if prefix == 'gm' else 'gcf'}_scores_str"]
-                    else []
-                )
+                if prefix == "gm":
+                    # Get the detailed data for this result
+                    detail = detailed_data.get(str(result["GCF ID"]), {})
+                    ids = (
+                        detail.get("spectrum_ids_str", "").split("|")
+                        if detail.get("spectrum_ids_str")
+                        else []
+                    )
+                    scores = (
+                        [float(s) for s in detail.get("spectrum_scores_str", "").split("|")]
+                        if detail.get("spectrum_scores_str")
+                        else []
+                    )
+                    mf_ids = (
+                        detail.get("spectrum_mf_ids_str", "").split("|")
+                        if detail.get("spectrum_mf_ids_str")
+                        else []
+                    )
+                else:  # MG
+                    # Get the detailed data for this result
+                    detail = detailed_data.get(str(result["MF ID"]), {})
+                    ids = (
+                        detail.get("gcf_ids_str", "").split("|")
+                        if detail.get("gcf_ids_str")
+                        else []
+                    )
+                    scores = (
+                        [float(s) for s in detail.get("gcf_scores_str", "").split("|")]
+                        if detail.get("gcf_scores_str")
+                        else []
+                    )
 
                 # Show only top 5 items in tooltip
                 max_tooltip_entries = 5
                 total_entries = len(ids)
 
                 if prefix == "gm":
-                    # Get MF IDs for tooltips (only for GM tab)
-                    mf_ids = (
-                        result.get("spectrum_mf_ids_str", "").split("|")
-                        if result.get("spectrum_mf_ids_str")
-                        else []
-                    )
-
                     items_table = "| Spectrum ID | MF ID | Score |\n|--------|--------|--------|\n"
 
                     # Add top entries for GM tab
-                    for item_id, score, mf_id in zip(
-                        ids[:max_tooltip_entries],
-                        scores[:max_tooltip_entries],
-                        mf_ids[:max_tooltip_entries],
-                    ):
+                    for idx in range(min(max_tooltip_entries, len(ids))):
+                        item_id = ids[idx] if idx < len(ids) else ""
+                        score = scores[idx] if idx < len(scores) else 0
+                        mf_id = mf_ids[idx] if idx < len(mf_ids) else ""
                         items_table += f"| {item_id} | {mf_id} | {round(float(score), 4)} |\n"
                 else:
                     items_table = "| GCF ID | Score |\n|--------|--------|\n"
                     # Add top entries for MG tab
-                    for item_id, score in zip(
-                        ids[:max_tooltip_entries], scores[:max_tooltip_entries]
-                    ):
+                    for idx in range(min(max_tooltip_entries, len(ids))):
+                        item_id = ids[idx] if idx < len(ids) else ""
+                        score = scores[idx] if idx < len(scores) else 0
                         items_table += f"| {item_id} | {round(float(score), 4)} |\n"
 
                 # Add indication of more entries if applicable
@@ -2099,7 +2105,17 @@ def update_results_datatable(
                 }
                 tooltip_data.append(row_tooltip)
 
-        return ("", False, results, tooltip_data, {"display": "block"}, {}, False, None)
+        return (
+            alert_message,
+            alert_message != "",
+            results,
+            tooltip_data,
+            {"display": "block"},
+            {},
+            False,
+            None,
+            detailed_data,
+        )
 
     except Exception as e:
         return (
@@ -2111,6 +2127,7 @@ def update_results_datatable(
             {"color": "#888888"},
             True,
             None,
+            {},
         )
 
 
@@ -2186,13 +2203,14 @@ def toggle_download_button(table_data):
     return False, False, ""
 
 
-def generate_excel(n_clicks, table_data, tab_prefix):
+def generate_excel(n_clicks, table_data, detailed_data, tab_prefix):
     """Generate Excel file with two sheets: full results and detailed data.
 
     Args:
         n_clicks: Number of clicks on the download button.
         table_data: Data from the results table.
         tab_prefix: Tab prefix ('gm' or 'mg').
+        detailed_data: Detailed data for each row in the table.
 
     Returns:
         Tuple containing the download component, alert visibility, alert message, and spinner state.
@@ -2205,82 +2223,54 @@ def generate_excel(n_clicks, table_data, tab_prefix):
         with pd.ExcelWriter(output, engine="xlsxwriter") as writer:
             # Sheet 1: Best candidate links table
             results_df = pd.DataFrame(table_data)
-
-            # Field names are different based on tab
-            if tab_prefix == "gm":
-                internal_fields = [
-                    "spectrum_ids_str",
-                    "spectrum_mf_ids_str",
-                    "spectrum_scores_str",
-                    "spectrum_mz_str",
-                    "spectrum_gnps_id_str",
-                ]
-                filename = "nplinker_genom_to_metabol.xlsx"
-                detail_id_field = "GCF ID"
-                item_id_field = "Spectrum ID"
-                detail_sheet_name = "All Candidate Links"
-            else:  # MG
-                internal_fields = [
-                    "gcf_ids_str",
-                    "gcf_scores_str",
-                    "gcf_bgc_classes_str",
-                    "gcf_bgc_ids_str",
-                    "gcf_num_bgcs_str",
-                ]
-                filename = "nplinker_metabol_to_genom.xlsx"
-                detail_id_field = "MF ID"
-                item_id_field = "GCF ID"
-                detail_sheet_name = "All Candidate Links"
-
-            # Filter out only the internal fields used for tooltips and processing
-            export_columns = [col for col in results_df.columns if col not in internal_fields]
-
-            # Use all non-internal columns
-            results_df = results_df[export_columns]
             results_df.to_excel(writer, sheet_name="Best Candidate Links", index=False)
 
             # Sheet 2: Detailed data
-            detailed_data = []
+            detailed_data_list = []
+
             for row in table_data:
-                primary_id = row[detail_id_field]
                 if tab_prefix == "gm":
+                    primary_id = row["GCF ID"]
+                    detail = detailed_data.get(str(primary_id), {})
+
+                    if not detail:
+                        continue
+
                     ids = (
                         [
                             int(s) if s and s != "None" else float("nan")
-                            for s in row.get("spectrum_ids_str", "").split("|")
+                            for s in detail.get("spectrum_ids_str", "").split("|")
                         ]
-                        if row.get("spectrum_ids_str")
+                        if detail.get("spectrum_ids_str")
                         else []
                     )
                     mf_ids = (
                         [
                             int(s) if s and s != "None" else float("nan")
-                            for s in row.get("spectrum_mf_ids_str", "").split("|")
+                            for s in detail.get("spectrum_mf_ids_str", "").split("|")
                         ]
-                        if row.get("spectrum_mf_ids_str")
+                        if detail.get("spectrum_mf_ids_str")
                         else []
                     )
                     scores = (
                         [
                             float(s) if s and s != "None" else float("nan")
-                            for s in row.get("spectrum_scores_str", "").split("|")
+                            for s in detail.get("spectrum_scores_str", "").split("|")
                         ]
-                        if row.get("spectrum_scores_str")
+                        if detail.get("spectrum_scores_str")
                         else []
                     )
-
                     mz_values = (
                         [
                             float(s) if s and s != "None" else float("nan")
-                            for s in row.get("spectrum_mz_str", "").split("|")
+                            for s in detail.get("spectrum_mz_str", "").split("|")
                         ]
-                        if row.get("spectrum_mz_str")
+                        if detail.get("spectrum_mz_str")
                         else []
                     )
-
                     gnps_ids = (
-                        row.get("spectrum_gnps_id_str", "").split("|")
-                        if row.get("spectrum_gnps_id_str")
+                        detail.get("spectrum_gnps_id_str", "").split("|")
+                        if detail.get("spectrum_gnps_id_str")
                         else []
                     )
 
@@ -2289,40 +2279,47 @@ def generate_excel(n_clicks, table_data, tab_prefix):
                         ids, mf_ids, scores, mz_values, gnps_ids
                     ):
                         detail_row = {
-                            detail_id_field: primary_id,
-                            item_id_field: item_id,
+                            "GCF ID": primary_id,
+                            "Spectrum ID": item_id,
                             "MF ID": mf_id,
                             "Score": score,
                             "Precursor m/z": mz,
                             "GNPS ID": gnps_id,
                         }
-                        detailed_data.append(detail_row)
+                        detailed_data_list.append(detail_row)
                 else:  # MG
-                    ids = row.get("gcf_ids_str", "").split("|") if row.get("gcf_ids_str") else []
+                    primary_id = row["MF ID"]
+                    detail = detailed_data.get(str(primary_id), {})
+
+                    if not detail:
+                        continue
+
+                    ids = (
+                        detail.get("gcf_ids_str", "").split("|")
+                        if detail.get("gcf_ids_str")
+                        else []
+                    )
                     scores = (
-                        [float(s) for s in row.get("gcf_scores_str", "").split("|")]
-                        if row.get("gcf_scores_str")
+                        [float(s) for s in detail.get("gcf_scores_str", "").split("|")]
+                        if detail.get("gcf_scores_str")
                         else []
                     )
-
                     bgc_classes = (
-                        row.get("gcf_bgc_classes_str", "").split("|")
-                        if row.get("gcf_bgc_classes_str")
+                        detail.get("gcf_bgc_classes_str", "").split("|")
+                        if detail.get("gcf_bgc_classes_str")
                         else []
                     )
-
                     bgc_ids = (
-                        row.get("gcf_bgc_ids_str", "").split("|")
-                        if row.get("gcf_bgc_ids_str")
+                        detail.get("gcf_bgc_ids_str", "").split("|")
+                        if detail.get("gcf_bgc_ids_str")
                         else []
                     )
-
                     num_bgcs = (
                         [
                             int(s) if s and s.isdigit() else 0
-                            for s in row.get("gcf_num_bgcs_str", "").split("|")
+                            for s in detail.get("gcf_num_bgcs_str", "").split("|")
                         ]
-                        if row.get("gcf_num_bgcs_str")
+                        if detail.get("gcf_num_bgcs_str")
                         else []
                     )
 
@@ -2331,20 +2328,25 @@ def generate_excel(n_clicks, table_data, tab_prefix):
                         ids, scores, bgc_classes, bgc_ids, num_bgcs
                     ):
                         detail_row = {
-                            detail_id_field: primary_id,
-                            item_id_field: int(item_id),
+                            "MF ID": primary_id,
+                            "GCF ID": int(item_id) if item_id.isdigit() else item_id,
                             "Score": score,
                             "BGC Classes": bgc_class,
                             "BGC IDs": bgc_id,
                             "# BGCs": num_bgc,
                         }
-                        detailed_data.append(detail_row)
+                        detailed_data_list.append(detail_row)
 
-            detailed_df = pd.DataFrame(detailed_data)
-            detailed_df.to_excel(writer, sheet_name=detail_sheet_name, index=False)
+            if detailed_data_list:
+                detailed_df = pd.DataFrame(detailed_data_list)
+                detail_sheet_name = "All Candidate Links"
+                detailed_df.to_excel(writer, sheet_name=detail_sheet_name, index=False)
 
         # Prepare the file for download
         excel_data = output.getvalue()
+        filename = (
+            f"nplinker_{'genom_to_metabol' if tab_prefix == 'gm' else 'metabol_to_genom'}.xlsx"
+        )
         return dcc.send_bytes(excel_data, filename), False, "", None
     except Exception as e:
         return None, True, f"Error generating Excel file: {str(e)}", None
@@ -2407,6 +2409,7 @@ def gm_update_columns(selected_columns: list[str] | None, n_clicks: int | None) 
     Output("gm-results-table-card-header", "style"),
     Output("gm-results-table-column-settings-button", "disabled"),
     Output("loading-spinner-container", "children", allow_duplicate=True),
+    Output("gm-detailed-data-store", "data"),
     Input("gm-results-button", "n_clicks"),
     Input("gm-table", "derived_virtual_data"),
     Input("gm-table", "derived_virtual_selected_rows"),
@@ -2464,12 +2467,13 @@ def gm_toggle_download_button(table_data):
     Input("gm-download-button", "n_clicks"),
     [
         State("gm-results-table", "data"),
+        State("gm-detailed-data-store", "data"),
     ],
     prevent_initial_call=True,
 )
-def gm_generate_excel(n_clicks, table_data):
+def gm_generate_excel(n_clicks, table_data, detailed_data):
     """Generate Excel file for GM data."""
-    return generate_excel(n_clicks, table_data, "gm")
+    return generate_excel(n_clicks, table_data, detailed_data, "gm")
 
 
 # ------------------ MG Results table functions ------------------ #
@@ -2529,6 +2533,7 @@ def mg_update_columns(selected_columns: list[str] | None, n_clicks: int | None) 
     Output("mg-results-table-card-header", "style"),
     Output("mg-results-table-column-settings-button", "disabled"),
     Output("loading-spinner-container", "children", allow_duplicate=True),
+    Output("mg-detailed-data-store", "data"),
     Input("mg-results-button", "n_clicks"),
     Input("mg-table", "derived_virtual_data"),
     Input("mg-table", "derived_virtual_selected_rows"),
@@ -2586,9 +2591,10 @@ def mg_toggle_download_button(table_data):
     Input("mg-download-button", "n_clicks"),
     [
         State("mg-results-table", "data"),
+        State("mg-detailed-data-store", "data"),
     ],
     prevent_initial_call=True,
 )
-def mg_generate_excel(n_clicks, table_data):
+def mg_generate_excel(n_clicks, table_data, detailed_data):
     """Generate Excel file for MG data."""
-    return generate_excel(n_clicks, table_data, "mg")
+    return generate_excel(n_clicks, table_data, detailed_data, "mg")

--- a/app/config.py
+++ b/app/config.py
@@ -87,3 +87,5 @@ MG_RESULTS_TABLE_CHECKL_OPTIONAL_COLUMNS = [
 
 # Scoring Configurations
 SCORING_DROPDOWN_MENU_OPTIONS = [{"label": "Metcalf", "value": "METCALF"}]
+
+MAX_TOOLTIP_ROWS = 500

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -38,13 +38,27 @@ def create_data_table(table_id, select_all_id):
         page_action="native",
         page_current=0,
         page_size=10,
-        style_cell={"textAlign": "left", "padding": "5px"},
+        style_cell={
+            "textAlign": "left",
+            "padding": "5px",
+            "overflow": "hidden",
+            "textOverflow": "ellipsis",
+            "minWidth": "80px",
+            "width": "auto",
+            "maxWidth": "200px",
+        },
         style_header={
             "backgroundColor": "#FF6E42",
             "fontWeight": "bold",
             "color": "white",
+            "whiteSpace": "normal",
+            "height": "auto",
         },
-        style_data={"border": "1px solid #ddd"},
+        style_data={
+            "border": "1px solid #ddd",
+            "whiteSpace": "normal",
+            "height": "auto",
+        },
         style_data_conditional=[
             {
                 "if": {"state": "selected"},

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -635,6 +635,8 @@ uploader = html.Div(
         dcc.Store(id="file-store"),  # Store to keep the file contents
         dcc.Store(id="processed-data-store"),  # Store to keep the processed data
         dcc.Store(id="processed-links-store"),  # Store to keep the processed links
+        dcc.Store(id="gm-detailed-data-store"),  # Store for GM detailed data
+        dcc.Store(id="mg-detailed-data-store"),  # Store for MG detailed data
     ],
     className="p-5 ml-5 mr-5",
 )

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -105,16 +105,15 @@ def create_results_table(table_id, no_sort_columns):
         editable=False,
         filter_action="none",
         sort_action="native",
+        virtualization=True,
+        fixed_rows={"headers": True},  # Keep headers visible when scrolling
         sort_mode="single",
         sort_as_null=["None", ""],
         sort_by=[],
         page_action="native",
         page_current=0,
-        page_size=10,
-        style_table={
-            "width": "100%",
-            "overflowX": "auto",
-        },
+        page_size=50,
+        style_table={"width": "100%", "overflowX": "auto", "overflowY": "auto"},
         style_cell={
             "textAlign": "left",
             "padding": "5px",

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -587,6 +587,7 @@ def test_gm_toggle_download_button():
 def test_gm_generate_excel_error_handling():
     """Test the generate_excel function error handling."""
     table_data = [{"GCF ID": 1, "spectrum_ids_str": "123"}]
+    detailed_data = {"1": {"spectrum_ids": ["123"]}}
 
     with (
         patch("app.callbacks.ctx") as mock_ctx,
@@ -596,7 +597,7 @@ def test_gm_generate_excel_error_handling():
         # Simulate an error during Excel generation
         mock_writer.side_effect = Exception("Excel write error")
 
-        result = gm_generate_excel(1, table_data)
+        result = gm_generate_excel(1, table_data, detailed_data)
 
         # Should return an error message
         assert result[0] is None
@@ -744,6 +745,7 @@ def test_mg_table_select_rows(sample_processed_data):
 def test_mg_generate_excel_error_handling():
     """Test the mg_generate_excel function error handling."""
     table_data = [{"MF ID": 1, "gcf_ids_str": "123"}]
+    detailed_data = {"1": {"spectrum_ids": ["123"]}}
 
     with (
         patch("app.callbacks.ctx") as mock_ctx,
@@ -753,7 +755,7 @@ def test_mg_generate_excel_error_handling():
         # Simulate an error during Excel generation
         mock_writer.side_effect = Exception("Excel write error")
 
-        result = mg_generate_excel(1, table_data)
+        result = mg_generate_excel(1, table_data, detailed_data)
 
         # Should return an error message
         assert result[0] is None


### PR DESCRIPTION
When loading pickle files with thousands of rows to be visualized in the results table, the app crashes with an `OSError: [Errno 22] Invalid argument`. This error occurs when the HTTP response size exceeds system limits.

Implemented Solutions:
- Pagination with 50 rows per page
- Virtualization (only renders rows currently visible in the viewport, and dynamically adds/removes rows during scrolling for better performance)

The issue is not solved yet. Other possibilities:

- Row Limiting. Could add a maximum row threshold with warning message when truncated. All the data would be still saved in the Excel file/s.
- Server-side pagination. Would allow handling arbitrarily large datasets if needed.
- Data chunking. Breaking large datasets into separately loaded pieces.