### PR TITLE
feat: add the possibility to change x-axis in the gm table plot

### DIFF
--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -277,7 +277,7 @@ def process_uploaded_data(
         Output("gm-filter-accordion-component", "value", allow_duplicate=True),
         Output("gm-scoring-accordion-component", "value", allow_duplicate=True),
         Output("gm-results-table-column-toggle", "value", allow_duplicate=True),
-        # MG tab outputs
+        Output("gm-graph-x-axis-selector", "value"),
         Output("mg-tab", "disabled"),
         Output("mg-filter-accordion-control", "disabled"),
         Output("mg-filter-blocks-id", "data", allow_duplicate=True),
@@ -337,6 +337,7 @@ def disable_tabs_and_reset_blocks(
             [],
             [],
             default_gm_column_value,
+            "n_bgcs",
             # MG tab - disabled
             True,
             True,
@@ -385,6 +386,7 @@ def disable_tabs_and_reset_blocks(
         [],
         [],
         default_gm_column_value,
+        "n_bgcs",
         # MG tab - enabled with initial blocks
         False,
         False,

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -408,9 +408,10 @@ def disable_tabs_and_reset_blocks(
 @app.callback(
     Output("gm-graph", "figure"),
     Output("gm-graph", "style"),
+    Output("gm-graph-selector-container", "style"),
     [Input("processed-data-store", "data"), Input("gm-graph-x-axis-selector", "value")],
 )
-def gm_plot(stored_data: str | None, x_axis_selection: str) -> tuple[dict | go.Figure, dict]:
+def gm_plot(stored_data: str | None, x_axis_selection: str) -> tuple[dict | go.Figure, dict, dict]:
     """Create a bar plot based on the processed data.
 
     Args:
@@ -418,10 +419,11 @@ def gm_plot(stored_data: str | None, x_axis_selection: str) -> tuple[dict | go.F
         x_axis_selection: Selected x-axis type ('n_bgcs' or 'class_bgcs').
 
     Returns:
-        Tuple containing the plot figure, style, and a status message.
+        Tuple containing the plot figure, style for graph, and style for selector.
     """
     if stored_data is None:
-        return {}, {"display": "none"}
+        return {}, {"display": "none"}, {"display": "none"}
+
     data = json.loads(stored_data)
 
     if x_axis_selection == "n_bgcs":
@@ -515,7 +517,7 @@ def gm_plot(stored_data: str | None, x_axis_selection: str) -> tuple[dict | go.F
             ),
         )
 
-    return fig, {"display": "block"}
+    return fig, {"display": "block"}, {"display": "block"}
 
 
 # ------------------ Common Filter and Table Functions ------------------ #

--- a/app/callbacks.py
+++ b/app/callbacks.py
@@ -128,7 +128,12 @@ def process_uploaded_data(
                 return ["Unknown"]
             return list(bgc_class)  # Convert tuple to list
 
-        processed_data: dict[str, Any] = {"n_bgcs": {}, "gcf_data": [], "mf_data": []}
+        processed_data: dict[str, Any] = {
+            "gcf_data": [],
+            "n_bgcs": {},
+            "class_bgcs": {},
+            "mf_data": [],
+        }
 
         for gcf in gcfs:
             sorted_bgcs = sorted(gcf.bgcs, key=lambda bgc: bgc.id)
@@ -148,6 +153,12 @@ def process_uploaded_data(
             if len(gcf.bgcs) not in processed_data["n_bgcs"]:
                 processed_data["n_bgcs"][len(gcf.bgcs)] = []
             processed_data["n_bgcs"][len(gcf.bgcs)].append(gcf.id)
+
+            for bgc_class_list in bgc_classes:
+                for bgc_class in bgc_class_list:
+                    if bgc_class not in processed_data["class_bgcs"]:
+                        processed_data["class_bgcs"][bgc_class] = []
+                    processed_data["class_bgcs"][bgc_class].append(gcf.id)
 
         for mf in mfs:
             sorted_spectra = sorted(mf.spectra, key=lambda spectrum: spectrum.id)

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -577,9 +577,10 @@ def create_tab_content(prefix, filter_title, checkl_options, no_sort_columns):
                             ),
                             width=12,
                         )
-                    ]
+                    ],
+                    id="gm-graph-selector-container",
                 ),
-                dcc.Graph(id="gm-graph", style={"display": "none"}),
+                dcc.Graph(id="gm-graph"),
             ],
             className="mt-5 mb-3",
         )

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -553,10 +553,40 @@ def create_tab_content(prefix, filter_title, checkl_options, no_sort_columns):
     # Add graph component only for GM tab
     components = []
     if prefix == "gm":
-        graph = dcc.Graph(id="gm-graph", className="mt-5 mb-3", style={"display": "none"})
+        # Add x-axis selector dropdown above the graph
+        graph_with_selector = html.Div(
+            [
+                dbc.Row(
+                    [
+                        dbc.Col(
+                            html.Div(
+                                [
+                                    html.Label("Select X-axis: ", className="me-2"),
+                                    dcc.Dropdown(
+                                        id="gm-graph-x-axis-selector",
+                                        options=[
+                                            {"label": "# BGCs", "value": "n_bgcs"},
+                                            {"label": "BGC Classes", "value": "class_bgcs"},
+                                        ],
+                                        value="n_bgcs",  # Default value
+                                        clearable=False,
+                                        style={"width": "200px"},
+                                    ),
+                                ],
+                                className="d-flex align-items-center mb-3",
+                            ),
+                            width=12,
+                        )
+                    ]
+                ),
+                dcc.Graph(id="gm-graph", style={"display": "none"}),
+            ],
+            className="mt-5 mb-3",
+        )
+
         components = [
             dbc.Col(filter_accordion, width=10, className="mx-auto dbc"),
-            dbc.Col(graph, width=10, className="mx-auto"),
+            dbc.Col(graph_with_selector, width=10, className="mx-auto"),
             dbc.Col(data_table, width=10, className="mx-auto"),
             dbc.Col(scoring_accordion, width=10, className="mx-auto dbc"),
         ]

--- a/app/layouts.py
+++ b/app/layouts.py
@@ -573,7 +573,7 @@ def create_tab_content(prefix, filter_title, checkl_options, no_sort_columns):
                                         style={"width": "200px"},
                                     ),
                                 ],
-                                className="d-flex align-items-center mb-3",
+                                className="d-flex align-items-center",
                             ),
                             width=12,
                         )
@@ -586,7 +586,7 @@ def create_tab_content(prefix, filter_title, checkl_options, no_sort_columns):
 
         components = [
             dbc.Col(filter_accordion, width=10, className="mx-auto dbc"),
-            dbc.Col(graph_with_selector, width=10, className="mx-auto"),
+            dbc.Col(graph_with_selector, width=10, className="mx-auto dbc"),
             dbc.Col(data_table, width=10, className="mx-auto"),
             dbc.Col(scoring_accordion, width=10, className="mx-auto dbc"),
         ]

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -193,9 +193,9 @@ def test_process_uploaded_data_structure():
 
     # Check that all gm_data lists have the same length
     gm_list_lengths = [len(processed_links["gm_data"][key]) for key in expected_gm_keys]
-    assert all(
-        length == gm_list_lengths[0] for length in gm_list_lengths
-    ), "GM link data lists have inconsistent lengths"
+    assert all(length == gm_list_lengths[0] for length in gm_list_lengths), (
+        "GM link data lists have inconsistent lengths"
+    )
 
     # Check spectrum structure in gm_data
     if gm_list_lengths[0] > 0:  # Only if there are any GM links
@@ -224,9 +224,9 @@ def test_process_uploaded_data_structure():
 
     # Check that all mg_data lists have the same length
     mg_list_lengths = [len(processed_links["mg_data"][key]) for key in expected_mg_keys]
-    assert all(
-        length == mg_list_lengths[0] for length in mg_list_lengths
-    ), "MG link data lists have inconsistent lengths"
+    assert all(length == mg_list_lengths[0] for length in mg_list_lengths), (
+        "MG link data lists have inconsistent lengths"
+    )
 
     # Check gcf structure in mg_data
     if mg_list_lengths[0] > 0:  # Only if there are any MG links
@@ -273,6 +273,7 @@ def test_disable_tabs(mock_uuid):
         [],
         [],
         default_gm_column_value,
+        "n_bgcs",
         # MG tab - disabled
         True,
         True,
@@ -312,6 +313,7 @@ def test_disable_tabs(mock_uuid):
         gm_filter_accordion_value,
         gm_scoring_accordion_value,
         gm_results_table_column_toggle,
+        gm_graph_dropdown,
         # MG tab outputs
         mg_tab_disabled,
         mg_filter_accordion_disabled,
@@ -348,6 +350,7 @@ def test_disable_tabs(mock_uuid):
     assert gm_filter_accordion_value == []
     assert gm_scoring_accordion_value == []
     assert gm_results_table_column_toggle == default_gm_column_value
+    assert gm_graph_dropdown == "n_bgcs"
 
     # Assert MG tab outputs
     assert mg_tab_disabled is False


### PR DESCRIPTION
I've added the option to plot the number of GCFs per BGC class, in addition to the number of BGCs, which was already implemented. Regarding the original issue (#34), I'm not entirely sure if we had additional functionalities in mind beyond this.

The note about "providing different plot styles for users to choose from, e.g., histogram, box plot" seems a bit pointless to me at this stage, as I don't see how this kind of data could be meaningfully represented using box plots instead of bar plots.

Maybe @justinjjvanderhooft you could take a look at the new functionality and let me know if there's anything else we should add?